### PR TITLE
Fixes js filename in organizing assets to jive with rest of compiling…

### DIFF
--- a/source/docs/compiling-assets.md
+++ b/source/docs/compiling-assets.md
@@ -29,7 +29,7 @@ By default, any assets you want to process with Mix should live in `/source/_ass
     <div class="folder folder--open">source
         <div class="folder folder--open focus">_assets
             <div class="folder folder--open">js
-                <div class="file">app.js</div>
+                <div class="file">main.js</div>
             </div>
             <div class="folder folder--open">css
                 <div class="file">main.css</div>
@@ -59,7 +59,7 @@ By default, once Webpack compiles your assets, they will be placed in their corr
     <div class="folder folder--open">source
         <div class="folder folder--open">_assets
             <div class="folder folder--open">js
-                <div class="file">app.js</div>
+                <div class="file">main.js</div>
             </div>
             <div class="folder folder--open">css
                 <div class="file">main.css</div>


### PR DESCRIPTION
… assets doc.

In the `Compiling Assets` docs page, the section on `Organizing Assets` is currently using the old `app.js` filename. The sections below in the webpack config file have already been updated to the current jigsaw's  `source/_assets/js/main.js`.  This small fix makes the filenames jive with the current usage in jigsaw.

(Sorry if this should have gone to `develop`, but that looks like a hairy branch, and this is a small docs fix)