### PR TITLE
docs build assets info also says production rather than prod

### DIFF
--- a/source/docs/compiling-assets.md
+++ b/source/docs/compiling-assets.md
@@ -121,7 +121,7 @@ Any time any file changes in your project, Webpack will recompile your assets, a
 
 Using `npm run watch` also enables [Browsersync](https://www.browsersync.io/), so your browser will automatically reload any time you make a change. It also manages serving your site locally for you, so you don't need to start your own local PHP server.
 
-You can also watch a specific environment by running `npm run local`, `npm run staging`, or `npm run production`.
+You can also watch a specific environment by running `npm run local`, `npm run staging`, or `npm run prod`.
 
 ---
 


### PR DESCRIPTION
Related to PR #78 

The docs for building assets say `npm run production`, but as per `package.json` it should be `npm run prod`