### PR TITLE
Change npm production to npm prod

### DIFF
--- a/source/docs/building-and-previewing-environments.md
+++ b/source/docs/building-and-previewing-environments.md
@@ -44,7 +44,7 @@ $ ./vendor/bin/jigsaw build production
 Alternatively, if you are [using Laravel Mix to compile your assets](/docs/compiling-assets), you can run the `production` script found in `package.json`:
 
 ```
-$ npm run production
+$ npm run prod
 ```
 
 This will generate your site into a new folder called `build_production`, leaving your `build_local` folder untouched.


### PR DESCRIPTION
This PR updates the reference from `npm production` in the Building & Previewing/Environments page to `npm prod`.