### PR TITLE
Add note about TailwindCSS v3

### DIFF
--- a/source/docs/compiling-assets.md
+++ b/source/docs/compiling-assets.md
@@ -192,3 +192,16 @@ You may choose to inline your CSS or JavaScript assets into the `<style>` or `<s
 
 To prevent URLs in your `.scss` files—such as background images and fonts—from being processed and modified by Mix, make sure the `processCssUrls` option is set to `false` in your `webpack.mix.js` file.
 
+### Note about using Tailwind CSS version 3
+
+Jigsaw uses Tailwind CSS version 2 by default. To use Tailwind CSS version 3, make sure to update the `tailwind.config` file to reflect the [Tailwind CSS v3 configuration](https://tailwindcss.com/docs/upgrade-guide#configure-content-sources). Use specific paths in your `content` array and only include directories that won't change when your CSS builds:
+
+```js
+module.exports = {
+    content: [
+        'source/index.blade.php',
+        'source/_layouts/**/*.blade.php',
+        'source/_assets/**/*.{js,css},
+    ]
+}
+```


### PR DESCRIPTION
If a user tries to upgrade TailwindCSS from version 2 to version 3, the `npm watch` process breaks and runs as an infinite loop. This PR adds a note about configuring the `tailwind.config` file to make the watcher run again.