### PR TITLE
Replace links to old Laravel docs, add note about Browsersync

### DIFF
--- a/source/docs/building-and-previewing.md
+++ b/source/docs/building-and-previewing.md
@@ -68,3 +68,5 @@ npm run watch
 _(If you haven't already, you'll need to run `npm install` before running `npm run watch`.)_
 
 Browsersync will automatically open a new browser tab and reload the page every time you make a change. Very helpful for previewing your changes quickly!
+
+Browsersync is only included in the [starter template](/docs/starter-templates) Jigsaw installation. If you are using the default Jigsaw installation, you will need to add it yourself.

--- a/source/docs/building-and-previewing.md
+++ b/source/docs/building-and-previewing.md
@@ -39,6 +39,18 @@ Using the default site structure, `/build_local` will look like this:
     <div class="ellipsis">...</div>
 </div>
 
+### Watching files for changes
+
+To compile the assets and keep watching your project for changes you can run the following command:
+
+```bash
+npm run watch
+```
+
+Your project will open at a localhost URL and any time any file changes in your project, Webpack will recompile your assets, and Jigsaw will regenerate your static HTML pages to `/build_local`.
+
+You can also watch a specific environment by running `npm run local`, `npm run staging`, or `npm run prod`.
+
 ### Previewing with PHP
 
 To quickly preview your site, use the `serve` command:
@@ -56,17 +68,3 @@ vendor/bin/jigsaw serve production --port=8080
 ```
 
 This will serve your `/build_production` directory at `http://localhost:8080`.
-
-### Previewing with Browsersync
-
-If you are [using Laravel Mix to compile your assets](/docs/compiling-assets) (which is included in the default Jigsaw setup), you can preview your site with Browsersync by simply running:
-
-```bash
-npm run watch
-```
-
-_(If you haven't already, you'll need to run `npm install` before running `npm run watch`.)_
-
-Browsersync will automatically open a new browser tab and reload the page every time you make a change. Very helpful for previewing your changes quickly!
-
-Browsersync is only included in the [starter template](/docs/starter-templates) Jigsaw installation. If you are using the default Jigsaw installation, you will need to add it yourself.

--- a/source/docs/building-and-previewing.md
+++ b/source/docs/building-and-previewing.md
@@ -41,15 +41,13 @@ Using the default site structure, `/build_local` will look like this:
 
 ### Watching files for changes
 
-To compile the assets and keep watching your project for changes you can run the following command:
+To compile your site's assets and keep watching for changes, you can run the following command:
 
 ```bash
 npm run watch
 ```
 
-Your project will open at a localhost URL and any time any file changes in your project, Webpack will recompile your assets, and Jigsaw will regenerate your static HTML pages to `/build_local`.
-
-You can also watch a specific environment by running `npm run local`, `npm run staging`, or `npm run prod`.
+Now, any time a file changes in your project, webpack will recompile your assets and Jigsaw will regenerate your updated static HTML pages to `/build_local`.
 
 ### Previewing with PHP
 

--- a/source/docs/collections.md
+++ b/source/docs/collections.md
@@ -114,7 +114,7 @@ This post is *profoundly* interesting.
 ### Accessing Collection Items
 
 In any Blade template, you have access to each of your collections using a variable with the collection's name. This variable references an object that contains all the elements in your collection, and can be iterated over to
-access individual collection items. The collection variable also behaves as if it were an [Illuminate Collection](https://laravel.com/docs/7.x/collections) in Laravel, meaning you have access to all of Laravel's standard collection methods like `count()`, `filter()`, and `where()`.
+access individual collection items. The collection variable also behaves as if it were an [Illuminate Collection](https://laravel.com/docs/collections) in Laravel, meaning you have access to all of Laravel's standard collection methods like `count()`, `filter()`, and `where()`.
 
 For example, to create a list of the titles for all your blog posts, you can iterate over the `$posts` object in a Blade `@foreach` loop, and display the `title` property that you defined in the YAML front matter of each post:
 

--- a/source/docs/compiling-assets.md
+++ b/source/docs/compiling-assets.md
@@ -5,7 +5,7 @@ section: documentation_content
 
 ## Compiling Assets with Laravel Mix
 
-Jigsaw sites are configured with support for [Laravel Mix](https://laravel.com/docs/7.x/mix) out of the box. If you've ever used Mix in a Laravel project, you already know how to use Mix with Jigsaw.
+Jigsaw sites are configured with support for [Laravel Mix](https://laravel.com/docs/mix) out of the box. If you've ever used Mix in a Laravel project, you already know how to use Mix with Jigsaw.
 
 ---
 
@@ -19,7 +19,7 @@ Once you have Node.js and NPM installed, pull in the dependencies needed to comp
 npm install
 ```
 
-For more detailed installation instructions, check out the [full Laravel Mix documentation](https://laravel.com/docs/7.x/mix).
+For more detailed installation instructions, check out the [full Laravel Mix documentation](https://laravel.com/docs/mix).
 
 ### Organizing your assets
 
@@ -118,8 +118,6 @@ npm run watch
 ```
 
 Any time any file changes in your project, Webpack will recompile your assets, and Jigsaw will regenerate your static HTML pages to `/build_local`.
-
-Using `npm run watch` also enables [Browsersync](https://www.browsersync.io/), so your browser will automatically reload any time you make a change. It also manages serving your site locally for you, so you don't need to start your own local PHP server.
 
 You can also watch a specific environment by running `npm run local`, `npm run staging`, or `npm run prod`.
 

--- a/source/docs/compiling-assets.md
+++ b/source/docs/compiling-assets.md
@@ -119,8 +119,6 @@ npm run watch
 
 Any time any file changes in your project, Webpack will recompile your assets, and Jigsaw will regenerate your static HTML pages to `/build_local`.
 
-You can also watch a specific environment by running `npm run local`, `npm run staging`, or `npm run prod`.
-
 ---
 
 ### Changing asset locations

--- a/source/docs/content-blade.md
+++ b/source/docs/content-blade.md
@@ -6,7 +6,7 @@ section: documentation_content
 #### [Creating Your Site's Content](/docs/content)
 ## Blade Templates & Partials
 
-One of the biggest benefits of a templating language is the ability to create reusable layouts and partials. Jigsaw gives you access to all the templating features and control structures of Blade that are available in Laravel (learn more about Blade layouts in the [official Blade documentation](https://laravel.com/docs/7.x/blade)).
+One of the biggest benefits of a templating language is the ability to create reusable layouts and partials. Jigsaw gives you access to all the templating features and control structures of Blade that are available in Laravel (learn more about Blade layouts in the [official Blade documentation](https://laravel.com/docs/blade)).
 
 ### Defining a Layout
 
@@ -167,7 +167,7 @@ Since the `_partials` directory starts with an underscore, those files won't be 
 
 ### Extending Blade with custom directives
 
-Jigsaw gives you the ability to extend Blade with [custom directives](https://laravel.com/docs/7.x/blade#extending-blade), just as you can with Laravel. To do this, create a `blade.php` file at the root level of your Jigsaw project (at the same level as `config.php`), and return an array of directives keyed by the directive name, each returning a closure.
+Jigsaw gives you the ability to extend Blade with [custom directives](https://laravel.com/docs/blade#extending-blade), just as you can with Laravel. To do this, create a `blade.php` file at the root level of your Jigsaw project (at the same level as `config.php`), and return an array of directives keyed by the directive name, each returning a closure.
 
 For example, you can create a custom `@datetime($timestamp)` directive to format a given integer timestamp as a date in your Blade templates:
 
@@ -181,7 +181,7 @@ return [
 ];
 ```
 
-Alternatively, the `blade.php` file receives a variable named `$bladeCompiler`, which exposes an instance of `\Illuminate\View\Compilers\BladeCompiler`. With this, you can create custom Blade directives, [aliased components](https://laravel.com/docs/7.x/blade#extending-blade), named `@include` statements, or other extended Blade control structures:
+Alternatively, the `blade.php` file receives a variable named `$bladeCompiler`, which exposes an instance of `\Illuminate\View\Compilers\BladeCompiler`. With this, you can create custom Blade directives, [aliased components](https://laravel.com/docs/blade#extending-blade), named `@include` statements, or other extended Blade control structures:
 
 > _blade.php_
 

--- a/source/docs/installation.md
+++ b/source/docs/installation.md
@@ -7,7 +7,7 @@ section: documentation_content
 
 ### System Requirements
 
-To use Jigsaw, you need to have PHP (minimum version 7.3) and [Composer](https://getcomposer.org/) installed on your machine. You'll also optionally need Node.js and NPM installed if you want to use [Laravel Mix](https://laravel.com/docs/7.x/mix) to compile your CSS and Javascript.
+To use Jigsaw, you need to have PHP (minimum version 7.3) and [Composer](https://getcomposer.org/) installed on your machine. You'll also optionally need Node.js and NPM installed if you want to use [Laravel Mix](https://laravel.com/docs/mix) to compile your CSS and Javascript.
 
 ---
 

--- a/source/docs/starter-templates.md
+++ b/source/docs/starter-templates.md
@@ -24,6 +24,7 @@ Both the `blog` and `docs` starter templates include samples of common page type
 - [Purgecss](https://www.purgecss.com/) to remove unused selectors from your CSS, resulting in smaller CSS files
 - Syntax highlighting using [highlight.js](https://highlightjs.org/)
 - A script that automatically generates a `sitemap.xml` file
+- [Browsersync](https://browsersync.io/) to automatically open a new browser tab and reload the page every time you make a change
 - A custom 404 page
 
 The `blog` template also includes:


### PR DESCRIPTION
This PR replaces links to Laravel docs version 7 with a link to the current Laravel doc version.

It also adds a small paragraph clarifying the use of Browsersync on a default Jigsaw installation.